### PR TITLE
Add tools for new functions in appointy agent toolkit

### DIFF
--- a/python/appointy_agent_toolkit/prompts.py
+++ b/python/appointy_agent_toolkit/prompts.py
@@ -26,3 +26,53 @@ It takes six arguments:
 - customer_name (str, optional): The name of the customer.
 - customer_email (str, optional): The email of the customer.
 """
+
+LIST_SERVICES_PROMPT = """
+This tool will list all services for the business.
+
+It takes one optional argument:
+- query (str, optional): Query string to filter services.
+"""
+
+GET_STAFF_INFO_PROMPT = """
+This tool will get available staff for a service.
+
+It takes two arguments:
+- service_id (str): The ID of the service.
+- duration (str): The duration of the service.
+"""
+
+GET_SERVICE_INFO_PROMPT = """
+This tool will get detailed service information.
+
+It takes one argument:
+- query (str): Query string to search for service.
+"""
+
+GET_AVAILABLE_DATES_PROMPT = """
+This tool will get available dates for booking.
+
+It takes three arguments:
+- filters (dict): Filters for available dates.
+- from_date (str): Start date for availability search.
+- to_date (str): End date for availability search.
+"""
+
+GET_AVAILABLE_SLOTS_PROMPT = """
+This tool will get available time slots for booking.
+
+It takes three arguments:
+- filters (dict): Filters for available slots.
+- from_date (str): Start date for availability search.
+- to_date (str): End date for availability search.
+"""
+
+GENERATE_BOOKING_LINK_PROMPT = """
+This tool will generate a booking link.
+
+It takes four arguments:
+- date (str): Date for the booking.
+- time (str): Time for the booking.
+- service_id (str): ID of the service.
+- employee_id (str): ID of the employee.
+"""

--- a/python/appointy_agent_toolkit/schema.py
+++ b/python/appointy_agent_toolkit/schema.py
@@ -21,3 +21,35 @@ class UpdateAppointment(BaseModel):
     end_time: Optional[str] = Field(None, description="End time of the appointment")
     customer_name: Optional[str] = Field(None, description="Name of the customer")
     customer_email: Optional[str] = Field(None, description="Email of the customer")
+
+
+class ListServices(BaseModel):
+    query: Optional[str] = Field(None, description="Query string to filter services")
+
+
+class GetStaffInfo(BaseModel):
+    service_id: str = Field(..., description="ID of the service")
+    duration: str = Field(..., description="Duration of the service")
+
+
+class GetServiceInfo(BaseModel):
+    query: str = Field(..., description="Query string to search for service")
+
+
+class GetAvailableDates(BaseModel):
+    filters: dict = Field(..., description="Filters for available dates")
+    from_date: str = Field(..., description="Start date for availability search")
+    to_date: str = Field(..., description="End date for availability search")
+
+
+class GetAvailableSlots(BaseModel):
+    filters: dict = Field(..., description="Filters for available slots")
+    from_date: str = Field(..., description="Start date for availability search")
+    to_date: str = Field(..., description="End date for availability search")
+
+
+class GenerateBookingLink(BaseModel):
+    date: str = Field(..., description="Date for the booking")
+    time: str = Field(..., description="Time for the booking")
+    service_id: str = Field(..., description="ID of the service")
+    employee_id: str = Field(..., description="ID of the employee")

--- a/python/appointy_agent_toolkit/tools.py
+++ b/python/appointy_agent_toolkit/tools.py
@@ -4,12 +4,24 @@ from .prompts import (
     CREATE_APPOINTMENT_PROMPT,
     LIST_APPOINTMENTS_PROMPT,
     UPDATE_APPOINTMENT_PROMPT,
+    LIST_SERVICES_PROMPT,
+    GET_STAFF_INFO_PROMPT,
+    GET_SERVICE_INFO_PROMPT,
+    GET_AVAILABLE_DATES_PROMPT,
+    GET_AVAILABLE_SLOTS_PROMPT,
+    GENERATE_BOOKING_LINK_PROMPT,
 )
 
 from .schema import (
     CreateAppointment,
     ListAppointments,
     UpdateAppointment,
+    ListServices,
+    GetStaffInfo,
+    GetServiceInfo,
+    GetAvailableDates,
+    GetAvailableSlots,
+    GenerateBookingLink,
 )
 
 tools: List[Dict] = [
@@ -43,6 +55,72 @@ tools: List[Dict] = [
         "actions": {
             "appointments": {
                 "update": True,
+            }
+        },
+    },
+    {
+        "method": "list_services",
+        "name": "List Services",
+        "description": LIST_SERVICES_PROMPT,
+        "args_schema": ListServices,
+        "actions": {
+            "services": {
+                "read": True,
+            }
+        },
+    },
+    {
+        "method": "get_staff_info",
+        "name": "Get Staff Info",
+        "description": GET_STAFF_INFO_PROMPT,
+        "args_schema": GetStaffInfo,
+        "actions": {
+            "staff": {
+                "read": True,
+            }
+        },
+    },
+    {
+        "method": "get_service_info",
+        "name": "Get Service Info",
+        "description": GET_SERVICE_INFO_PROMPT,
+        "args_schema": GetServiceInfo,
+        "actions": {
+            "services": {
+                "read": True,
+            }
+        },
+    },
+    {
+        "method": "get_available_dates",
+        "name": "Get Available Dates",
+        "description": GET_AVAILABLE_DATES_PROMPT,
+        "args_schema": GetAvailableDates,
+        "actions": {
+            "availability": {
+                "read": True,
+            }
+        },
+    },
+    {
+        "method": "get_available_slots",
+        "name": "Get Available Slots",
+        "description": GET_AVAILABLE_SLOTS_PROMPT,
+        "args_schema": GetAvailableSlots,
+        "actions": {
+            "availability": {
+                "read": True,
+            }
+        },
+    },
+    {
+        "method": "generate_booking_link",
+        "name": "Generate Booking Link",
+        "description": GENERATE_BOOKING_LINK_PROMPT,
+        "args_schema": GenerateBookingLink,
+        "actions": {
+            "booking": {
+                "create": True,
             }
         },
     },


### PR DESCRIPTION
Add tools, schemas, and prompts for new functions in `appointy_agent_toolkit`.

* **Tools**: Add tools for `list_services`, `get_staff_info`, `get_service_info`, `get_available_dates`, `get_available_slots`, and `generate_booking_link` in `python/appointy_agent_toolkit/tools.py`.
* **Schemas**: Add corresponding schemas for the new functions in `python/appointy_agent_toolkit/schema.py`.
* **Prompts**: Add prompts for the new functions in `python/appointy_agent_toolkit/prompts.py`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HarshJa1n/stripe-agent-toolkit/pull/1?shareId=a9ba7494-ae35-425b-8d62-6c60b59e1bea).